### PR TITLE
Framebuffer using `embedded-graphics-framebuf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-dma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "embedded-graphics"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +204,16 @@ checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
 dependencies = [
  "az",
  "byteorder",
+]
+
+[[package]]
+name = "embedded-graphics-framebuf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22354420f68727fa24d1e2741dae1e9a041065e80fb63b35a8d19c647a85be76"
+dependencies = [
+ "embedded-dma",
+ "embedded-graphics",
 ]
 
 [[package]]
@@ -390,6 +409,7 @@ name = "mousefood"
 version = "0.0.1"
 dependencies = [
  "embedded-graphics",
+ "embedded-graphics-framebuf",
  "embedded-graphics-simulator",
  "ibm437",
  "ratatui",
@@ -586,6 +606,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude=["/.idea/", "/.github/"]
 [dependencies]
 ratatui = { version = "0.29", default-features = false, features = ["all-widgets"] }
 embedded-graphics = "0.8.1"
+embedded-graphics-framebuf = "0.5.0"
 embedded-graphics-simulator = { version = "0.7.0", optional = true }
 ibm437 = { version = "0.3.3", optional = true }
 

--- a/examples/simulator.rs
+++ b/examples/simulator.rs
@@ -7,8 +7,8 @@ use ratatui::widgets::{Block, Paragraph, Wrap};
 
 fn main() -> Result<(), std::io::Error> {
     let mut display = SimulatorDisplay::<Bgr565>::new(geometry::Size::new(128, 64));
-    let backend: EmbeddedBackend<SimulatorDisplay<Bgr565>, Bgr565> =
-        EmbeddedBackend::new(&mut display, None, None);
+    let backend: EmbeddedBackend<SimulatorDisplay<Bgr565>, _, { 128 * 64 }> =
+        EmbeddedBackend::new(&mut display);
     let mut terminal = Terminal::new(backend)?;
 
     loop {


### PR DESCRIPTION
As of now, this doesn't work on esp32, but works in simulation. Probably related to DMA implementation - leaving it for now as I don't have a jtag debugger yet.