### PR TITLE
Bump `embedded-graphics-unicodefonts` to v0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics-unicodefonts"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1864581d1d2ad0edf4178459b93dd602303b8687e739f15f130fc4af75cf14bb"
+checksum = "4ae29a3546b748029042d5e1311cbf45cde05dd96ed4b762762e50fcad6f4746"
 dependencies = [
  "embedded-graphics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude=["/.idea/", "/.github/"]
 ratatui = { version = "0.29", default-features = false, features = ["all-widgets"] }
 embedded-graphics = "0.8.1"
 embedded-graphics-simulator = { version = "0.7.0", optional = true }
-embedded-graphics-unicodefonts = { version = "0.0.1", optional = true }
+embedded-graphics-unicodefonts = { version = "0.0.3", optional = true }
 
 [features]
 default = ["fonts"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,8 @@ pub use embedded_graphics_unicodefonts as fonts;
 
 #[cfg(feature = "fonts")]
 mod default_font {
-    pub use embedded_graphics_unicodefonts::BASIC_6X10 as bold;
-    pub use embedded_graphics_unicodefonts::BASIC_6X10 as regular;
+    pub use embedded_graphics_unicodefonts::MONO_6X10 as bold;
+    pub use embedded_graphics_unicodefonts::MONO_6X10 as regular;
 }
 #[cfg(not(feature = "fonts"))]
 mod default_font {


### PR DESCRIPTION
BREAKING CHANGE: `fonts::BASIC_6X10` renamed to `fonts::MONO_6X10`