### PR TITLE
Add support for underlining text in different colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["embedded"]
 exclude=["/.idea/", "/.github/"]
 
 [dependencies]
-ratatui = { version = "0.29", default-features = false, features = ["all-widgets"] }
+ratatui = { version = "0.29", default-features = false, features = ["all-widgets", "underline-color"] }
 embedded-graphics = "0.8.1"
 embedded-graphics-simulator = { version = "0.7.0", optional = true }
 embedded-graphics-unicodefonts = { version = "0.0.3", optional = true }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -194,6 +194,12 @@ where
                 }
             }
 
+            if cell.underline_color != style::Color::Reset {
+                style_builder = style_builder.underline_with_color(
+                    TermColor(cell.underline_color, TermColorType::Foreground).into(),
+                );
+            }
+
             Text::new(
                 cell.symbol(),
                 position + self.char_offset,


### PR DESCRIPTION
Note: can't merge it yet, gotta wait for `ratatui=0.30` since the `underline-color` feature currently pulls in `crossterm` as an additional dependency.