### PR TITLE
feat(no_std): make the crate no-std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,53 @@ jobs:
         run: cargo test --locked --lib --features epd-weact
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+
+  build-no-std:
+    name: build [no-std] ${{ matrix.target }} ${{ matrix.toolchain }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - arm-unknown-linux-gnueabi
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - thumbv6m-none-eabi
+          - thumbv7em-none-eabi
+          - thumbv7em-none-eabihf
+          - thumbv7m-none-eabi
+        toolchain: [ "1.85.0", "stable" ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --target ${{ matrix.target }}
+
+  build-espidf-std:
+    name: build [std] ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - riscv32imc-esp-espidf
+          - riscv32imac-esp-espidf
+          - xtensa-esp32-espidf
+          - xtensa-esp32s2-espidf
+          - xtensa-esp32s3-espidf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        if: matrix.target == 'riscv32imc-esp-espidf'
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy, rust-src
+      - uses: esp-rs/xtensa-toolchain@v1.5.1
+        if: matrix.target != 'riscv32imc-esp-espidf'
+        with:
+          default: true
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,13 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          # no alloc
-          # - thumbv6m-none-eabi
           - thumbv7em-none-eabi
           - thumbv7em-none-eabihf
           - thumbv7m-none-eabi
-          - xtensa-esp32-none-elf
-          - xtensa-esp32s2-none-elf
-          - xtensa-esp32s3-none-elf
-          - riscv32imc-unknown-none-elf # esp32c2, esp32c3
-          - riscv32imac-unknown-none-elf # esp32c6, esp32h2
+          # no alloc::sync, required by kasuari
+          # - thumbv6m-none-eabi
+          # - riscv32imc-unknown-none-elf # esp32c2, esp32c3
+          # - riscv32imac-unknown-none-elf # esp32c6, esp32h2
         toolchain: [ "1.85.0", "stable" ]
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +105,26 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
+          components:
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --target ${{ matrix.target }}
+
+  build-xtensa-no-std:
+    name: build [no-std] ${{ matrix.target }} esp
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - xtensa-esp32-none-elf
+          - xtensa-esp32s2-none-elf
+          - xtensa-esp32s3-none-elf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: esp-rs/xtensa-toolchain@v1.5.1
+        with:
+          default: true
+          buildtargets: 'all'
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
 
@@ -117,24 +134,17 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - riscv32imc-esp-espidf
-          - riscv32imac-esp-espidf
+          - riscv32imc-esp-espidf # esp32c2, esp32c3
+          - riscv32imac-esp-espidf # esp32c6, esp32h2
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        if: matrix.target == 'riscv32imc-esp-espidf'
-        with:
-          toolchain: nightly
-          components: rustfmt, clippy, rust-src
-          target: ${{ matrix.target }}
       - uses: esp-rs/xtensa-toolchain@v1.5.1
-        if: matrix.target != 'riscv32imc-esp-espidf'
         with:
           default: true
           buildtargets: 'all'
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+      - run: cargo build --release --features=std --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           default: true
           ldproxy: false
-          buildtargets: 'xtensa-esp32-none-elf,xtensa-esp32s2-none-elf,xtensa-esp32s3-none-elf'
+          buildtargets: 'esp32,esp32s2,esp32s3'
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
 
@@ -147,6 +147,6 @@ jobs:
         with:
           default: true
           ldproxy: true
-          buildtargets: 'riscv32imc-esp-espidf,riscv32imac-esp-espidf,xtensa-esp32-espidf,xtensa-esp32s2-espidf,xtensa-esp32s3-espidf'
+          buildtargets: 'esp32,esp32s2,esp32s3,esp32c2,esp32c3,esp32c6,esp32h2'
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --features=std --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
 
@@ -118,14 +119,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@v4
         if: matrix.target == 'riscv32imc-esp-espidf'
         with:
           toolchain: nightly
           components: rustfmt, clippy, rust-src
+          target: ${{ matrix.target }}
       - uses: esp-rs/xtensa-toolchain@v1.5.1
         if: matrix.target != 'riscv32imc-esp-espidf'
         with:
           default: true
+          buildtargets: 'all'
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --target ${{ matrix.target }}
+      - run: cargo build --release --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,11 @@ jobs:
           - thumbv7em-none-eabi
           - thumbv7em-none-eabihf
           - thumbv7m-none-eabi
-          - riscv32imc-unknown-none-elf
-          - riscv32imac-unknown-none-elf
+          - xtensa-esp32-none-elf
+          - xtensa-esp32s2-none-elf
+          - xtensa-esp32s3-none-elf
+          - riscv32imc-unknown-none-elf # esp32c2, esp32c3
+          - riscv32imac-unknown-none-elf # esp32c6, esp32h2
         toolchain: [ "1.85.0", "stable" ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,8 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - thumbv6m-none-eabi
+          # no alloc
+          # - thumbv6m-none-eabi
           - thumbv7em-none-eabi
           - thumbv7em-none-eabihf
           - thumbv7m-none-eabi
@@ -119,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         if: matrix.target == 'riscv32imc-esp-espidf'
         with:
           toolchain: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,8 @@ jobs:
           - thumbv7em-none-eabi
           - thumbv7em-none-eabihf
           - thumbv7m-none-eabi
+          - riscv32imc-unknown-none-elf
+          - riscv32imac-unknown-none-elf
         toolchain: [ "1.85.0", "stable" ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,26 +109,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
 
-  build-xtensa-no-std:
-    name: build [no-std] ${{ matrix.target }} esp
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - xtensa-esp32-none-elf
-          - xtensa-esp32s2-none-elf
-          - xtensa-esp32s3-none-elf
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: esp-rs/xtensa-toolchain@v1.5.4
-        with:
-          default: true
-          ldproxy: false
-          buildtargets: 'esp32,esp32s2,esp32s3'
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --target ${{ matrix.target }}
-
   build-espidf-std:
     name: build [std] ${{ matrix.target }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: esp-rs/xtensa-toolchain@v1.5.1
+      - uses: esp-rs/xtensa-toolchain@v1.5.4
         with:
           default: true
-          buildtargets: 'all'
+          ldproxy: false
+          buildtargets: 'xtensa-esp32-none-elf,xtensa-esp32s2-none-elf,xtensa-esp32s3-none-elf'
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --target ${{ matrix.target }}
 
@@ -142,9 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: esp-rs/xtensa-toolchain@v1.5.1
+      - uses: esp-rs/xtensa-toolchain@v1.5.4
         with:
           default: true
-          buildtargets: 'all'
+          ldproxy: true
+          buildtargets: 'riscv32imc-esp-espidf,riscv32imac-esp-espidf,xtensa-esp32-espidf,xtensa-esp32s2-espidf,xtensa-esp32s3-espidf'
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --features=std --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v4
+      - uses: dtolnay/rust-toolchain@master
         if: matrix.target == 'riscv32imc-esp-espidf'
         with:
           toolchain: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,12 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "castaway"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,9 +94,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -215,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics-unicodefonts"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae29a3546b748029042d5e1311cbf45cde05dd96ed4b762762e50fcad6f4746"
+checksum = "0ef96f7e6453093b9ffc738fb025f1a14c31f7f67a5d587db99beb23ab8b433a"
 dependencies = [
  "embedded-graphics",
 ]
@@ -334,9 +328,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -418,6 +412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "kasuari"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def1b67294a9fdc95eeeeafd1209c7a1b8a82aa0bf80ac2ab2a7d0318e9c7622"
+dependencies = [
+ "hashbrown",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +432,15 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce9d1fb615cfbfabb113034d9fcd9e717f8f7ccbf5dde59af2bc2dd223f9d26"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "lru"
@@ -506,7 +519,9 @@ dependencies = [
  "embedded-graphics-unicodefonts",
  "paste",
  "ratatui",
+ "ratatui-core",
  "rstest",
+ "thiserror",
  "weact-studio-epd",
 ]
 
@@ -523,15 +538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -659,23 +665,52 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "39fbb739119e808c9d3121bb62f434dc8104c83f31b1e0726b6e8a73c80b83eb"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e72d14ff9b26a022827e9b97c546f0d044dc0b689a2dabd1a4698a887db8f4b"
 dependencies = [
  "bitflags 2.9.0",
- "cassowary",
  "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961633cb7cabfcd341a11f4b8e922279ee62b7d908b1f2606c2be847cd7ede61"
+dependencies = [
+ "bitflags 2.9.0",
+ "hashbrown",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -806,26 +841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,17 +918,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "time"
 version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
- "serde",
  "time-core",
 ]
 
@@ -960,20 +992,14 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown",
 ]
@@ -665,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0-alpha.3"
+version = "0.30.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fbb739119e808c9d3121bb62f434dc8104c83f31b1e0726b6e8a73c80b83eb"
+checksum = "63bfff7501cc6892821f54f1133661e0534413342c8e8efbb41af0ffccdcea45"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -676,15 +685,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e72d14ff9b26a022827e9b97c546f0d044dc0b689a2dabd1a4698a887db8f4b"
+checksum = "353047185fbfb81ee05a3f8c573956adb2aa9a505da47fb150c18388806f5e22"
 dependencies = [
  "bitflags 2.9.0",
  "compact_str",
  "hashbrown",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -696,15 +705,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961633cb7cabfcd341a11f4b8e922279ee62b7d908b1f2606c2be847cd7ede61"
+checksum = "fab55e77e0421bb88944cc0262317688e039d0e58518195f13a6e689f3e22f42"
 dependencies = [
  "bitflags 2.9.0",
  "hashbrown",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -875,18 +884,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -996,7 +1005,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,21 @@ categories = ["embedded"]
 exclude=["/.github", "/assets"]
 
 [dependencies]
-ratatui = { version = "0.29", default-features = false, features = ["all-widgets"] }
+ratatui-core = { version = "0.1.0-alpha.4", features = ["underline-color"]}
+thiserror = { version = "2.0.12", default-features = false }
 embedded-graphics = "0.8.1"
 embedded-graphics-simulator = { version = "0.7.0", optional = true }
-embedded-graphics-unicodefonts = { version = "0.0.3", optional = true }
+embedded-graphics-unicodefonts = { version = "0.1.0", optional = true }
 weact-studio-epd = { version = "0.1.2", features = ["blocking"], optional = true }
 
 [dev-dependencies]
+ratatui = { version = "0.30.0-alpha.3", default-features = false }
 rstest = "0.25.0"
 paste = "1.0.15"
 
 [features]
 default = ["fonts"]
+std = ["thiserror/std", "ratatui-core/std"]
 simulator = ["dep:embedded-graphics-simulator"]
 fonts = ["dep:embedded-graphics-unicodefonts"]
 epd-weact = ["dep:weact-studio-epd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["embedded"]
 exclude=["/.github", "/assets"]
 
 [dependencies]
-ratatui-core = { version = "0.1.0-alpha.4", features = ["underline-color"]}
+ratatui-core = { version = "0.1.0-alpha.5", features = ["underline-color"]}
 thiserror = { version = "2.0.12", default-features = false }
 embedded-graphics = "0.8.1"
 embedded-graphics-simulator = { version = "0.7.0", optional = true }
@@ -20,7 +20,7 @@ embedded-graphics-unicodefonts = { version = "0.1.0", optional = true }
 weact-studio-epd = { version = "0.1.2", features = ["blocking"], optional = true }
 
 [dev-dependencies]
-ratatui = { version = "0.30.0-alpha.3", default-features = false }
+ratatui = { version = "0.30.0-alpha.4", default-features = false }
 rstest = "0.25.0"
 paste = "1.0.15"
 

--- a/examples/simulator.rs
+++ b/examples/simulator.rs
@@ -1,10 +1,12 @@
 //! Example using a simulator.
 use mousefood::embedded_graphics::geometry;
+use mousefood::error::Error;
 use mousefood::prelude::*;
-use mousefood::ratatui::widgets::{Block, Paragraph, Wrap};
 use mousefood::simulator::SimulatorDisplay;
+use ratatui::widgets::{Block, Paragraph, Wrap};
+use ratatui::{style::*, Frame, Terminal};
 
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<(), Error> {
     let mut display = SimulatorDisplay::<Bgr565>::new(geometry::Size::new(128, 64));
     let backend: EmbeddedBackend<SimulatorDisplay<_>, _> =
         EmbeddedBackend::new(&mut display, EmbeddedBackendConfig::default());

--- a/examples/simulator.rs
+++ b/examples/simulator.rs
@@ -4,7 +4,7 @@ use mousefood::error::Error;
 use mousefood::prelude::*;
 use mousefood::simulator::SimulatorDisplay;
 use ratatui::widgets::{Block, Paragraph, Wrap};
-use ratatui::{style::*, Frame, Terminal};
+use ratatui::{Frame, Terminal, style::*};
 
 fn main() -> Result<(), Error> {
     let mut display = SimulatorDisplay::<Bgr565>::new(geometry::Size::new(128, 64));

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,9 +1,8 @@
+use alloc::boxed::Box;
 use core::marker::PhantomData;
-use std::io;
 
 use crate::colors::*;
 use crate::default_font;
-use crate::error::DrawError;
 use crate::framebuffer;
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::geometry::{self, Dimensions};
@@ -13,9 +12,9 @@ use embedded_graphics::text::Text;
 use embedded_graphics::Drawable;
 #[cfg(feature = "simulator")]
 use embedded_graphics_simulator::{OutputSettings, SimulatorDisplay, SimulatorEvent, Window};
-use ratatui::backend::Backend;
-use ratatui::layout;
-use ratatui::style;
+use ratatui_core::backend::{Backend, ClearType};
+use ratatui_core::layout;
+use ratatui_core::style;
 
 /// Embedded backend configuration.
 pub struct EmbeddedBackendConfig<D, C>
@@ -150,30 +149,31 @@ where
     }
 
     #[cfg(feature = "simulator")]
-    fn update_simulation(&mut self) -> io::Result<()> {
+    fn update_simulation(&mut self) -> Result<()> {
         self.simulator_window.update(self.display);
         if self
             .simulator_window
             .events()
             .any(|e| e == SimulatorEvent::Quit)
         {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "simulator window closed",
-            ));
+            return Err(crate::error::Error::SimulatorQuit);
         }
         Ok(())
     }
 }
+
+type Result<T, E = crate::error::Error> = core::result::Result<T, E>;
 
 impl<D, C> Backend for EmbeddedBackend<'_, D, C>
 where
     D: DrawTarget<Color = C> + 'static,
     C: PixelColor + Into<Rgb888> + From<Rgb888> + From<TermColor> + 'static,
 {
-    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    type Error = crate::error::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<()>
     where
-        I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+        I: Iterator<Item = (u16, u16, &'a ratatui_core::buffer::Cell)>,
     {
         for (x, y, cell) in content {
             let position = geometry::Point::new(
@@ -213,22 +213,22 @@ where
                 style_builder.build(),
             )
             .draw(&mut self.buffer)
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, DrawError))?;
+            .map_err(|_| crate::error::Error::DrawError)?;
         }
         Ok(())
     }
 
-    fn hide_cursor(&mut self) -> io::Result<()> {
+    fn hide_cursor(&mut self) -> Result<()> {
         // TODO
         Ok(())
     }
 
-    fn show_cursor(&mut self) -> io::Result<()> {
+    fn show_cursor(&mut self) -> Result<()> {
         // TODO
         Ok(())
     }
 
-    fn get_cursor_position(&mut self) -> io::Result<layout::Position> {
+    fn get_cursor_position(&mut self) -> Result<layout::Position> {
         // TODO
         Ok(layout::Position::new(0, 0))
     }
@@ -236,32 +236,44 @@ where
     fn set_cursor_position<P: Into<layout::Position>>(
         &mut self,
         #[allow(unused_variables)] position: P,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         // TODO
         Ok(())
     }
 
-    fn clear(&mut self) -> io::Result<()> {
+    fn clear(&mut self) -> Result<()> {
         self.buffer
-            .clear(TermColor(ratatui::style::Color::Reset, TermColorType::Background).into())
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, DrawError))
+            .clear(TermColor(style::Color::Reset, TermColorType::Background).into())
+            .map_err(|_| crate::error::Error::DrawError)
     }
 
-    fn size(&self) -> io::Result<layout::Size> {
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<()> {
+        match clear_type {
+            ClearType::All => self.clear(),
+            ClearType::AfterCursor
+            | ClearType::BeforeCursor
+            | ClearType::CurrentLine
+            | ClearType::UntilNewLine => Err(crate::error::Error::ClearTypeUnsupported(
+                alloc::format!("{:?}", clear_type),
+            )),
+        }
+    }
+
+    fn size(&self) -> Result<layout::Size> {
         Ok(self.columns_rows)
     }
 
-    fn window_size(&mut self) -> io::Result<ratatui::backend::WindowSize> {
-        Ok(ratatui::backend::WindowSize {
+    fn window_size(&mut self) -> Result<ratatui_core::backend::WindowSize> {
+        Ok(ratatui_core::backend::WindowSize {
             columns_rows: self.columns_rows,
             pixels: self.pixels,
         })
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    fn flush(&mut self) -> Result<()> {
         self.display
             .fill_contiguous(&self.display.bounding_box(), &self.buffer)
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, DrawError))?;
+            .map_err(|_| crate::error::Error::DrawError)?;
         (self.flush_callback)(self.display);
         #[cfg(feature = "simulator")]
         self.update_simulation()?;

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -2,7 +2,7 @@ use crate::macros::for_all_rgb_colors;
 use embedded_graphics::pixelcolor::{
     Bgr555, Bgr565, Bgr666, Bgr888, BinaryColor, Rgb555, Rgb565, Rgb666, Rgb888, RgbColor,
 };
-use ratatui::style::Color;
+use ratatui_core::style::Color;
 
 pub enum TermColorType {
     Foreground,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,16 @@
-use core::{error, fmt};
+//! Mousefood `Error` enum.
 
-#[derive(Debug)]
-pub struct DrawError;
-
-impl error::Error for DrawError {}
-
-impl fmt::Display for DrawError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "writing to display failed")
-    }
+/// Represents backend error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Drawing to the display failed.
+    #[error("drawing to DrawTarget failed")]
+    DrawError,
+    /// Selected [`ClearType`] is not supported by Mousefood.
+    #[error("ClearType::{0} is not supported by Mousefood")]
+    ClearTypeUnsupported(alloc::string::String),
+    /// Simulator window was closed.
+    #[cfg(feature = "simulator")]
+    #[error("simulator window closed")]
+    SimulatorQuit,
 }

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -1,11 +1,12 @@
+use alloc::{vec, vec::IntoIter, vec::Vec};
+
 use crate::colors::{TermColor, TermColorType};
-use alloc::vec::IntoIter;
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::geometry::Dimensions;
 use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::primitives::Rectangle;
 use embedded_graphics::Pixel;
-use ratatui::style::Color;
+use ratatui_core::style::Color;
 
 pub(crate) struct HeapBuffer<C: PixelColor + Copy> {
     pub data: Vec<C>,
@@ -50,7 +51,7 @@ impl<C: PixelColor> Dimensions for HeapBuffer<C> {
 
 impl<C: PixelColor> DrawTarget for HeapBuffer<C> {
     type Color = C;
-    type Error = std::io::Error;
+    type Error = core::convert::Infallible;
 
     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
     where

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -8,7 +8,6 @@ use embedded_graphics::pixelcolor::PixelColor;
 use embedded_graphics::primitives::Rectangle;
 use ratatui_core::style::Color;
 
-
 pub(crate) struct HeapBuffer<C: PixelColor + Copy> {
     pub data: Vec<C>,
     bounding_box: Rectangle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![doc = include_str!("../README.md")]
 
 extern crate alloc;
@@ -5,14 +6,13 @@ extern crate alloc;
 mod backend;
 mod colors;
 mod default_font;
-mod error;
+pub mod error;
 mod framebuffer;
 mod macros;
 pub mod prelude;
 
 pub use backend::{EmbeddedBackend, EmbeddedBackendConfig};
 pub use embedded_graphics;
-pub use ratatui;
 
 #[cfg(feature = "simulator")]
 pub use embedded_graphics_simulator as simulator;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,4 +10,3 @@ pub use crate::backend::{EmbeddedBackend, EmbeddedBackendConfig};
 pub use embedded_graphics::pixelcolor::{
     Bgr555, Bgr565, Bgr666, Bgr888, Rgb555, Rgb565, Rgb666, Rgb888,
 };
-pub use ratatui::prelude::*;


### PR DESCRIPTION
Resolves #59, #36, #29

BREAKING CHANGE: `ratatui` is no longer re-exported; `Backend` now uses `mousefood::error::Error` instead of `std::io::Error` for error handling