### PR TITLE
docs(error): Fix link to `ratatui_core::backend::ClearType` enum

### DIFF
--- a/mousefood/src/error.rs
+++ b/mousefood/src/error.rs
@@ -6,7 +6,8 @@ pub enum Error {
     /// Drawing to the display failed.
     #[error("drawing to DrawTarget failed")]
     DrawError,
-    /// Selected [`ClearType`] is not supported by Mousefood.
+
+    /// Selected [`ClearType`](ratatui_core::backend::ClearType) is not supported by Mousefood.
     #[error("ClearType::{0} is not supported by Mousefood")]
     ClearTypeUnsupported(alloc::string::String),
 }


### PR DESCRIPTION
Fixed a rustdoc error linking to an enum of `ratatui_core`.