### PR TITLE
Don't reset to regular font on match None for bold and italic

### DIFF
--- a/mousefood/src/backend.rs
+++ b/mousefood/src/backend.rs
@@ -195,12 +195,12 @@ where
             for modifier in cell.modifier.iter() {
                 style_builder = match modifier {
                     style::Modifier::BOLD => match &self.font_bold {
-                        None => style_builder.font(&self.font_regular),
+                        None => style_builder,
                         Some(font) => style_builder.font(font),
                     },
                     style::Modifier::DIM => style_builder, // TODO
                     style::Modifier::ITALIC => match &self.font_italic {
-                        None => style_builder.font(&self.font_regular),
+                        None => style_builder,
                         Some(font) => style_builder.font(font),
                     },
                     style::Modifier::UNDERLINED => style_builder.underline(),


### PR DESCRIPTION
We already set font when first creating the style_builder, no need to reset it. This might also be wiping a previous setting. For example, if it has both italics and bold modifier, italics font is applied, but bold matches none, and resets font back to regular, we want to avoid such a behavior I assume. 