### PR TITLE
chore(ci): move immediate-abort panic strategy to RUSTFLAGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,4 +161,6 @@ jobs:
         with:
           default: true
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --release --features=std --target ${{ matrix.target }} -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort
+      - run: cargo build --release --features=std --target ${{ matrix.target }} -Zbuild-std=std,panic_abort
+        env:
+          RUSTFLAGS: "-Zunstable-options -Cpanic=immediate-abort"


### PR DESCRIPTION
panic_immediate_abort is now a first-class panic strategy, so it must be enabled
via rustc flags instead of build-std features.
