### PR TITLE
feat!: Remove `framebuffer` from the public API

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -4,7 +4,9 @@ This document lists all breaking changes along with tips to help you migrate smo
 
 ## Summary
 
-- [v0.3.0](#v030---unreleased) - unreleased
+- [unreleased](#unreleased)
+  - framebuffer module is no longer part of the public API
+- [v0.3.0](#v030)
   - Feature `simulator` is removed
   - Type of `EmbeddedBackendConfig::font_bold` is now `Option<MonoFont<'static>>`
   - `EmbeddedBackendConfig` now requires providing `font_italic`
@@ -20,7 +22,13 @@ This document lists all breaking changes along with tips to help you migrate smo
   - `EmbeddedBackend::new` now takes different arguments
 - [v0.0.1](#v001---initial-release) - initial release
 
-## v0.3.0 - unreleased
+## Unreleased
+
+### `framebuffer` module is no longer part of the public API ([#149])
+
+[#149]: https://github.com/ratatui/mousefood/pull/149
+
+## [v0.3.0](https://github.com/ratatui/mousefood/releases/tag/0.3.0)
 
 ### Feature `simulator` is removed ([#83])
 

--- a/mousefood/src/lib.rs
+++ b/mousefood/src/lib.rs
@@ -8,7 +8,7 @@ mod colors;
 mod default_font;
 pub mod error;
 #[cfg(feature = "framebuffer")]
-pub mod framebuffer;
+mod framebuffer;
 mod macros;
 pub mod prelude;
 


### PR DESCRIPTION
Previously required by #66, #100, making these private again as this shouldn't be needed anymore and currently only clutters the API exposing internal logic.