### PR TITLE
perf(framebuffer): avoid cloning during flush for every frame

### DIFF
--- a/mousefood/src/framebuffer.rs
+++ b/mousefood/src/framebuffer.rs
@@ -74,12 +74,12 @@ impl<C: PixelColor> IntoIterator for HeapBuffer<C> {
     }
 }
 
-impl<C: PixelColor> IntoIterator for &HeapBuffer<C> {
+impl<'a, C: PixelColor + Copy> IntoIterator for &'a HeapBuffer<C> {
     type Item = C;
-    type IntoIter = IntoIter<Self::Item>;
+    type IntoIter = core::iter::Copied<core::slice::Iter<'a, C>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.data.clone().into_iter()
+        self.data.iter().copied()
     }
 }
 


### PR DESCRIPTION
In my tests, I experienced this problem after each `Terminal::draw`
call:

```
PanicInfo { message: memory allocation of 1073608832 bytes failed }
```

That's a whopping 1.0 GiB of allocation. This happens because the
`&HeapBuffer` iterator cloned the entire framebuffer on each flush,
allocating `width × height × sizeof(C)` bytes per frame.
My guess is, on 32-bit embedded targets this can overflow and appear
as a massive allocation request.

The fix is to have the iterator borrow the existing buffer and yield
copied pixels instead, eliminating heap allocations on every frame.
